### PR TITLE
Refactor for use of VHDL Libraries

### DIFF
--- a/rtl/CLinkGateway.vhd
+++ b/rtl/CLinkGateway.vhd
@@ -18,9 +18,11 @@ use ieee.std_logic_1164.all;
 use IEEE.std_logic_unsigned.all;
 use IEEE.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
-use work.AxiLitePkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
 
 entity CLinkGateway is
    generic (
@@ -206,7 +208,7 @@ begin
    --------------------------
    -- AXI-Lite: Crossbar Core
    --------------------------  
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 2,
@@ -260,7 +262,7 @@ begin
 --   ------------------
 --   -- I2C PROM Module
 --   ------------------  
---   U_AxiI2cEeprom : entity work.AxiI2cEeprom
+--   U_AxiI2cEeprom : entity surf.AxiI2cEeprom
 --      generic map (
 --         TPD_G          => TPD_G,
 --         ADDR_WIDTH_G   => 13,          -- (64kb:  ADDR_WIDTH_G = 13)

--- a/rtl/CLinkGateway.vhd
+++ b/rtl/CLinkGateway.vhd
@@ -120,7 +120,7 @@ architecture mapping of CLinkGateway is
 begin
 
    GEN_PGP3 : if (PGP_TYPE_G = true) generate
-      U_PGP : entity work.Pgp3Phy
+      U_PGP : entity clink_gateway_fw_lib.Pgp3Phy
          generic map (
             TPD_G           => TPD_G,
             SIMULATION_G    => SIMULATION_G,
@@ -163,7 +163,7 @@ begin
    end generate;
 
    GEN_PGP2b : if (PGP_TYPE_G = false) generate
-      U_PGP : entity work.Pgp2bPhy
+      U_PGP : entity clink_gateway_fw_lib.Pgp2bPhy
          generic map (
             TPD_G           => TPD_G,
             SIMULATION_G    => SIMULATION_G,
@@ -229,7 +229,7 @@ begin
    -----------------
    -- System Modules
    -----------------
-   U_FpgaSystem : entity work.FpgaSystem
+   U_FpgaSystem : entity clink_gateway_fw_lib.FpgaSystem
       generic map (
          TPD_G           => TPD_G,
          SIMULATION_G    => SIMULATION_G,
@@ -284,7 +284,7 @@ begin
    ----------------
    -- CLink Wrapper
    ----------------
-   U_CLinkWrapper : entity work.CLinkWrapper
+   U_CLinkWrapper : entity clink_gateway_fw_lib.CLinkWrapper
       generic map (
          TPD_G            => TPD_G,
          CHAN_COUNT_G     => CHAN_COUNT_G,
@@ -331,7 +331,7 @@ begin
    -----------------
    -- Trigger Module
    -----------------  
-   U_Trig : entity work.TriggerTop
+   U_Trig : entity clink_gateway_fw_lib.TriggerTop
       generic map (
          TPD_G           => TPD_G,
          SIMULATION_G    => SIMULATION_G,

--- a/rtl/CLinkWrapper.vhd
+++ b/rtl/CLinkWrapper.vhd
@@ -18,12 +18,14 @@ use ieee.std_logic_1164.all;
 use IEEE.std_logic_unsigned.all;
 use IEEE.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
-use work.AxiLitePkg.all;
-use work.SsiPkg.all;
-use work.Pgp3Pkg.all;
-use work.ClinkPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.SsiPkg.all;
+use surf.Pgp3Pkg.all;
+use surf.ClinkPkg.all;
 
 entity CLinkWrapper is
    generic (
@@ -88,7 +90,7 @@ architecture mapping of CLinkWrapper is
 
 begin
 
-   U_ClinkTop : entity work.ClinkTop
+   U_ClinkTop : entity surf.ClinkTop
       generic map (
          TPD_G              => TPD_G,
          CHAN_COUNT_G       => CHAN_COUNT_G,
@@ -144,7 +146,7 @@ begin
    GEN_VEC :
    for i in (CHAN_COUNT_G-1) downto 0 generate
 
-      U_DataFifoA : entity work.AxiStreamFifoV2
+      U_DataFifoA : entity surf.AxiStreamFifoV2
          generic map (
             TPD_G               => TPD_G,
             SLAVE_READY_EN_G    => true,
@@ -171,7 +173,7 @@ begin
          txSlaveB(i)        <= txSlaveC(i);
       end process;
 
-      U_DataFifoB : entity work.AxiStreamFifoV2
+      U_DataFifoB : entity surf.AxiStreamFifoV2
          generic map (
             TPD_G               => TPD_G,
             SLAVE_READY_EN_G    => true,

--- a/rtl/FpgaSystem.vhd
+++ b/rtl/FpgaSystem.vhd
@@ -18,9 +18,11 @@ use ieee.std_logic_1164.all;
 use IEEE.std_logic_unsigned.all;
 use IEEE.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
-use work.I2cPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.I2cPkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
@@ -95,7 +97,7 @@ begin
    --------------------------
    -- AXI-Lite: Crossbar Core
    --------------------------  
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 1,
@@ -116,7 +118,7 @@ begin
    ---------------------------
    -- AXI-Lite: Version Module
    ---------------------------          
-   U_AxiVersion : entity work.AxiVersion
+   U_AxiVersion : entity surf.AxiVersion
       generic map (
          TPD_G           => TPD_G,
          BUILD_INFO_G    => BUILD_INFO_G,
@@ -140,7 +142,7 @@ begin
       ------------------------------
       -- AXI-Lite: Boot Flash Module
       ------------------------------
-      U_BootProm : entity work.AxiMicronN25QCore
+      U_BootProm : entity surf.AxiMicronN25QCore
          generic map (
             TPD_G          => TPD_G,
             AXI_CLK_FREQ_G => AXI_CLK_FREQ_G,        -- units of Hz
@@ -182,7 +184,7 @@ begin
       ----------------------
       -- AXI-Lite: Power I2C
       ----------------------
-      U_PwrI2C : entity work.AxiI2cRegMaster
+      U_PwrI2C : entity surf.AxiI2cRegMaster
          generic map (
             TPD_G          => TPD_G,
             DEVICE_MAP_G   => PWR_I2C_C,
@@ -204,7 +206,7 @@ begin
       -----------------------
       -- AXI-Lite XADC Module
       -----------------------
-      U_Xadc : entity work.AxiXadcMinimumCore
+      U_Xadc : entity surf.AxiXadcMinimumCore
          port map (
             -- XADC Ports
             vPIn           => vPIn,
@@ -222,7 +224,7 @@ begin
       -- AXI-Lite: SFP I2C
       --------------------
       GEN_VEC : for i in 3 downto 0 generate
-         U_SfpI2C : entity work.Sff8472
+         U_SfpI2C : entity surf.Sff8472
             generic map (
                TPD_G          => TPD_G,
                I2C_SCL_FREQ_G => 400.0E+3,  -- units of Hz

--- a/rtl/Pgp2bPhy.vhd
+++ b/rtl/Pgp2bPhy.vhd
@@ -242,7 +242,7 @@ begin
             dataIn  => pgpRxOut(i).opCodeEn,
             dataOut => pgpTrigger(i));
 
-      U_PgpVcWrapper : entity work.PgpVcWrapper
+      U_PgpVcWrapper : entity clink_gateway_fw_lib.PgpVcWrapper
          generic map (
             TPD_G            => TPD_G,
             SIMULATION_G     => SIMULATION_G,

--- a/rtl/Pgp2bPhy.vhd
+++ b/rtl/Pgp2bPhy.vhd
@@ -16,11 +16,13 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
-use work.AxiStreamPkg.all;
-use work.Pgp3Pkg.all;
-use work.Pgp2bPkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.Pgp3Pkg.all;
+use surf.Pgp2bPkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
@@ -118,7 +120,7 @@ begin
          I => pgpRefClkDiv2,
          O => pgpRefClkDiv2Bufg);
 
-   U_PwrUpRst : entity work.PwrUpRst
+   U_PwrUpRst : entity surf.PwrUpRst
       generic map(
          TPD_G         => TPD_G,
          SIM_SPEEDUP_G => SIMULATION_G)
@@ -126,7 +128,7 @@ begin
          clk    => pgpRefClkDiv2Bufg,
          rstOut => pgpRefClkDiv2Rst);
 
-   U_MMCM : entity work.ClockManager7
+   U_MMCM : entity surf.ClockManager7
       generic map(
          TPD_G              => TPD_G,
          SIMULATION_G       => SIMULATION_G,
@@ -152,7 +154,7 @@ begin
          rstOut(1) => sysRst,
          rstOut(2) => pgpRst);
 
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 1,
@@ -173,7 +175,7 @@ begin
    GEN_VEC :
    for i in 1 downto 0 generate
 
-      U_PGP : entity work.Pgp2bGtx7VarLat
+      U_PGP : entity surf.Pgp2bGtx7VarLat
          generic map (
             TPD_G             => TPD_G,
             -- CPLL Configurations
@@ -232,7 +234,7 @@ begin
             pgpRxMasters     => pgpRxMasters(4*i+3 downto 4*i),
             pgpRxCtrl        => pgpRxCtrl(4*i+3 downto 4*i));
 
-      U_SyncTrig : entity work.SynchronizerOneShot
+      U_SyncTrig : entity surf.SynchronizerOneShot
          generic map (
             TPD_G => TPD_G)
          port map (
@@ -276,7 +278,7 @@ begin
       --------------         
       -- PGP Monitor
       --------------         
-      U_PgpMon : entity work.Pgp2bAxi
+      U_PgpMon : entity surf.Pgp2bAxi
          generic map (
             TPD_G              => TPD_G,
             COMMON_TX_CLK_G    => false,
@@ -307,7 +309,7 @@ begin
       -----------------------------
       -- Monitor the PGP TX streams
       -----------------------------
---      U_AXIS_TX_MON : entity work.AxiStreamMonAxiL
+--      U_AXIS_TX_MON : entity surf.AxiStreamMonAxiL
 --         generic map(
 --            TPD_G            => TPD_G,
 --            COMMON_CLK_G     => false,
@@ -331,7 +333,7 @@ begin
       -----------------------------
       -- Monitor the PGP RX streams
       -----------------------------
---      U_AXIS_RX_MON : entity work.AxiStreamMonAxiL
+--      U_AXIS_RX_MON : entity surf.AxiStreamMonAxiL
 --         generic map(
 --            TPD_G            => TPD_G,
 --            COMMON_CLK_G     => false,

--- a/rtl/Pgp3Phy.vhd
+++ b/rtl/Pgp3Phy.vhd
@@ -16,10 +16,12 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
-use work.AxiStreamPkg.all;
-use work.Pgp3Pkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
+use surf.AxiStreamPkg.all;
+use surf.Pgp3Pkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
@@ -102,7 +104,7 @@ begin
    axilClk <= sysClk;
    axilRst <= sysRst;
 
-   U_PwrUpRst : entity work.PwrUpRst
+   U_PwrUpRst : entity surf.PwrUpRst
       generic map(
          TPD_G         => TPD_G,
          SIM_SPEEDUP_G => SIMULATION_G)
@@ -110,7 +112,7 @@ begin
          clk    => pgpRefClkDiv2,
          rstOut => pgpRefClkDiv2Rst);
 
-   U_MMCM : entity work.ClockManager7
+   U_MMCM : entity surf.ClockManager7
       generic map(
          TPD_G              => TPD_G,
          SIMULATION_G       => SIMULATION_G,
@@ -133,7 +135,7 @@ begin
          rstOut(0) => refRst200MHz,
          rstOut(1) => sysRst);
 
-   U_XBAR : entity work.AxiLiteCrossbar
+   U_XBAR : entity surf.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
          NUM_SLAVE_SLOTS_G  => 1,
@@ -151,7 +153,7 @@ begin
          mAxiReadMasters     => phyReadMasters,
          mAxiReadSlaves      => phyReadSlaves);
 
-   U_PGPv3 : entity work.Pgp3Gtx7Wrapper
+   U_PGPv3 : entity surf.Pgp3Gtx7Wrapper
       generic map(
          TPD_G                => TPD_G,
          ROGUE_SIM_EN_G       => SIMULATION_G,
@@ -205,7 +207,7 @@ begin
    GEN_VEC :
    for i in 1 downto 0 generate
 
-      U_SyncTrig : entity work.SynchronizerOneShot
+      U_SyncTrig : entity surf.SynchronizerOneShot
          generic map (
             TPD_G => TPD_G)
          port map (
@@ -249,7 +251,7 @@ begin
       -----------------------------
       -- Monitor the PGP TX streams
       -----------------------------
---      U_AXIS_TX_MON : entity work.AxiStreamMonAxiL
+--      U_AXIS_TX_MON : entity surf.AxiStreamMonAxiL
 --         generic map(
 --            TPD_G            => TPD_G,
 --            COMMON_CLK_G     => false,
@@ -273,7 +275,7 @@ begin
       -----------------------------
       -- Monitor the PGP RX streams
       -----------------------------
---      U_AXIS_RX_MON : entity work.AxiStreamMonAxiL
+--      U_AXIS_RX_MON : entity surf.AxiStreamMonAxiL
 --         generic map(
 --            TPD_G            => TPD_G,
 --            COMMON_CLK_G     => false,

--- a/rtl/Pgp3Phy.vhd
+++ b/rtl/Pgp3Phy.vhd
@@ -215,7 +215,7 @@ begin
             dataIn  => pgpRxOut(i).opCodeEn,
             dataOut => pgpTrigger(i));
 
-      U_PgpVcWrapper : entity work.PgpVcWrapper
+      U_PgpVcWrapper : entity clink_gateway_fw_lib.PgpVcWrapper
          generic map (
             TPD_G            => TPD_G,
             SIMULATION_G     => SIMULATION_G,

--- a/rtl/PgpVcWrapper.vhd
+++ b/rtl/PgpVcWrapper.vhd
@@ -18,10 +18,12 @@ use ieee.std_logic_1164.all;
 use IEEE.std_logic_unsigned.all;
 use IEEE.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiStreamPkg.all;
-use work.AxiLitePkg.all;
-use work.Pgp3Pkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiStreamPkg.all;
+use surf.AxiLitePkg.all;
+use surf.Pgp3Pkg.all;
 
 entity PgpVcWrapper is
    generic (
@@ -61,7 +63,7 @@ architecture mapping of PgpVcWrapper is
 
 begin
 
-   U_Vc0 : entity work.SrpV3AxiLite
+   U_Vc0 : entity surf.SrpV3AxiLite
       generic map (
          TPD_G               => TPD_G,
          SLAVE_READY_EN_G    => SIMULATION_G,
@@ -87,7 +89,7 @@ begin
          mAxilWriteMaster => axilWriteMaster,
          mAxilWriteSlave  => axilWriteSlave);
 
-   U_Vc1_Tx : entity work.AxiStreamFifoV2
+   U_Vc1_Tx : entity surf.AxiStreamFifoV2
       generic map (
          -- General Configurations
          TPD_G               => TPD_G,
@@ -112,7 +114,7 @@ begin
          mAxisMaster => pgpTxMasters(1),
          mAxisSlave  => pgpTxSlaves(1));
 
-   U_Vc2_Tx : entity work.AxiStreamFifoV2
+   U_Vc2_Tx : entity surf.AxiStreamFifoV2
       generic map (
          -- General Configurations
          TPD_G               => TPD_G,
@@ -137,7 +139,7 @@ begin
          mAxisMaster => pgpTxMasters(2),
          mAxisSlave  => pgpTxSlaves(2));
 
-   U_Vc2_Rx : entity work.AxiStreamFifoV2
+   U_Vc2_Rx : entity surf.AxiStreamFifoV2
       generic map (
          TPD_G               => TPD_G,
          SLAVE_READY_EN_G    => SIMULATION_G,

--- a/rtl/TriggerTop.vhd
+++ b/rtl/TriggerTop.vhd
@@ -18,8 +18,10 @@ use ieee.std_logic_1164.all;
 use IEEE.std_logic_unsigned.all;
 use IEEE.std_logic_arith.all;
 
-use work.StdRtlPkg.all;
-use work.AxiLitePkg.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use surf.AxiLitePkg.all;
 
 library unisim;
 use unisim.vcomponents.all;
@@ -103,7 +105,7 @@ begin
          ODIV2 => timingClkDiv2,
          O     => timingClk);
 
-   U_TerminateGtx : entity work.Gtxe2ChannelDummy
+   U_TerminateGtx : entity surf.Gtxe2ChannelDummy
       generic map (
          TPD_G   => TPD_G,
          WIDTH_G => 2)
@@ -117,7 +119,7 @@ begin
    GEN_TRIG_FREQ :
    for i in 1 downto 0 generate
 
-      U_trigFreq : entity work.SyncTrigRate
+      U_trigFreq : entity surf.SyncTrigRate
          generic map (
             TPD_G          => TPD_G,
             COMMON_CLK_G   => true,

--- a/ruckus.tcl
+++ b/ruckus.tcl
@@ -18,7 +18,7 @@ if { [info exists ::env(OVERRIDE_SUBMODULE_LOCKS)] != 1 || $::env(OVERRIDE_SUBMO
 }
 
 # Load local source Code 
-loadSource      -dir "$::DIR_PATH/rtl"
+loadSource -lib clink_gateway_fw_lib      -dir "$::DIR_PATH/rtl"
 
 # Load local source Code
 loadConstraints -path "$::DIR_PATH/xdc/ClinkGateway.xdc"


### PR DESCRIPTION
This change refactors the code to expect [SURF](https://github.com/slaclab/surf) and  modules and packages to be in a `surf` VHDL library.

It also refactors the code to place it's own modules and packages in a `clink_gateway_fw_lib` library.

This PR can't be merged until the corresponding changes in `surf` are merged.
 - https://github.com/slaclab/surf/pull/541